### PR TITLE
Guard against bad plugin or bad plugin data. Report and skip doc.

### DIFF
--- a/pgsync/plugin.py
+++ b/pgsync/plugin.py
@@ -81,25 +81,30 @@ class Plugins(object):
         for doc in docs:
             skip_doc = False
 
-            for plugin in self.plugins:
-                logger.debug(f"Plugin: {plugin.name}")
+            try:
+                for plugin in self.plugins:
+                    logger.debug(f"Plugin: {plugin.name}")
 
-                dx = plugin.transform(
-                    doc["_source"],
-                    _id=doc["_id"],
-                    _index=doc["_index"],
-                    _fulldoc=doc,
-                )
+                    dx = plugin.transform(
+                        doc["_source"],
+                        _id=doc["_id"],
+                        _index=doc["_index"],
+                        _fulldoc=doc,
+                    )
 
-                if isinstance(dx, (typing.List, typing.Tuple)):
-                    for item in dx:
-                        docs.append(item)
-                    skip_doc = True
-                    break
-                elif dx is None:
-                    skip_doc = True
-                else:
-                    doc["_source"] = dx
+                    if isinstance(dx, (typing.List, typing.Tuple)):
+                        for item in dx:
+                            docs.append(item)
+                        skip_doc = True
+                        break
+                    elif dx is None:
+                        skip_doc = True
+                    else:
+                        doc["_source"] = dx
+            except Exception as e:
+                logger.exeption("Plugin or data problem")
+                logger.warning(f"Continuing on skipping document: {doc}")
+                skip_doc = True
 
             if skip_doc:
                 continue


### PR DESCRIPTION
If we have a plugin bug or a document that doesn't play well with our plugins the system will crash and not be able to keep syncing up documents.

This skips and logs crashes from plugins.  The resulting data and/or plugin can be corrected and fixed later.  The end result is that some data might not make it to elasticsearch.  But not being able to search for some data is better than synchronization being off-line in total.