### PR TITLE
SST-643RedisSortedSets

### DIFF
--- a/pgsync/base.py
+++ b/pgsync/base.py
@@ -862,7 +862,7 @@ class Base(object):
     def fetchmany(self, statement, chunk_size=None):
         chunk_size = chunk_size or QUERY_CHUNK_SIZE
         logger.debug(f"Chunk size: {chunk_size}")
-        with self.__engine.connect() as conn:
+        with self.__engine.begin() as conn:
             logger.debug(f"Executing query...")
             result = conn.execution_options(stream_results=True).execute(
                 statement.select()

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -1009,10 +1009,11 @@ class Sync(Base):
     def poll_redis(self) -> None:
         """Consumer which polls Redis continuously."""
         while True:
-            payloads = self.redis.bulk_pop()
-            if payloads:
+            payload_tuples = self.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
                 logger.debug(f"poll_redis: {payloads}")
-                self.on_publish(payloads)
+                self.on_publish(payloads, txn_ids)
             time.sleep(REDIS_POLL_INTERVAL)
 
     @threaded
@@ -1058,12 +1059,14 @@ class Sync(Base):
             while conn.notifies:
                 notification = conn.notifies.pop(0)
                 payload = json.loads(notification.payload)
-                self.redis.push(payload)
+                # Use the txn_id as the redis score
+                txn_id = payload.pop('xmin')
+                self.redis.push(payload, txn_id)
                 logger.debug(f"on_notify: {payload}")
                 j += 1
             i = 0
 
-    def on_publish(self, payloads: Dict) -> None:
+    def on_publish(self, payloads: Dict, txn_ids) -> None:
         """
         Redis publish event handler.
 
@@ -1105,7 +1108,7 @@ class Sync(Base):
                     self.sync(self._payloads(_payloads))
                     _payloads = []
 
-        txids = set(map(lambda x: x["xmin"], payloads))
+        txids = set(txn_ids)
         # for truncate, tg_op txids is None so skip setting the checkpoint
         if txids != set([None]):
             txmin = min(min(txids), self.txid_current) - 1

--- a/tests/test_redisqueue.py
+++ b/tests/test_redisqueue.py
@@ -1,9 +1,47 @@
 """RedisQueues tests."""
 import pytest
-
+import json
+from pgsync.redisqueue import RedisQueue
+from pgsync.utils import get_redis_url
 
 @pytest.mark.usefixtures("table_creator")
 class TestRedisQueue(object):
     """Redis Queue tests."""
+    redis_queue = RedisQueue(name="test",namespace="testns", password="PLEASE_CHANGE_ME")
+
+    redis_queue._delete()
+
+    dummy_value = {}
+    dummy_value['a'] = 1
+    dummy_value['b'] = 2
+    dummy_value['c'] = 3
+    dummy_value['f'] = 22
+    redis_queue.push(dummy_value, 1)
+
+    assert(redis_queue.qsize() == 1)
+
+    dv_result = redis_queue.pop()[1]
+    assert(dv_result.get('b') == 2)
+    assert(dv_result.get('a') == 1)
+    assert(dv_result.get('d') == None)
+
+    assert(redis_queue.empty())
+
+    dummy_value2 = {}
+    dummy_value2['e'] = 34
+    redis_queue.bulk_push([(1,dummy_value), (2,dummy_value2)])
+
+    assert(redis_queue.qsize() == 2)
+
+    items = redis_queue.bulk_pop()
+    assert(len(items) == 2)
+
+    # Check bulk payloads
+    assert(items[0][1]['f'] == 22)
+    assert(items[1][1]['e'] == 34)
+
+    # Check score
+    assert(items[1][0] == 2)
+    assert(redis_queue.empty())
 
     pass


### PR DESCRIPTION
Swapped pgsync to used redis sorted sets rather than a list and keep txnids out of payload.  This is super helpful to be able to de-dup redis records easily. The txnid is often the only difference in the payloads. 

An optimization to keep the queue from getting too backed up.  This works because the "pop" grabs the ones with the lowest "scores" (txnids in our case), which are the oldest.