### PR TITLE
Changed init to queue up slot change with redis

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -54,12 +54,16 @@ class TestSync(object):
                 "pgsync.sync.Sync.logical_slot_get_changes"
             ) as mock_get:
                 with patch("pgsync.sync.Sync.sync") as mock_sync:
-                    sync.logical_slot_changes()
-                    mock_peek.assert_called_once_with(
-                        "testdb_testdb",
-                        txmin=None,
-                        txmax=None,
-                        upto_nchanges=None,
-                    )
-                    mock_get.assert_called_once()
-                    mock_sync.assert_called_once()
+                    with patch(
+                        "pgsync.redisqueue.RedisQueue.push"
+                    ) as mock_redis_push:
+                        sync.logical_slot_changes()
+                        mock_peek.assert_called_once_with(
+                            "testdb_testdb",
+                            txmin=None,
+                            txmax=None,
+                            upto_nchanges=None,
+                        )
+                        mock_get.assert_called_once()
+                        mock_sync.assert_not_called()
+                        mock_redis_push.assert_called_once()

--- a/tests/test_sync_nested_children.py
+++ b/tests/test_sync_nested_children.py
@@ -879,6 +879,11 @@ class TestNestedChildren(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():

--- a/tests/test_sync_root.py
+++ b/tests/test_sync_root.py
@@ -440,6 +440,11 @@ class TestRoot(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -578,6 +583,11 @@ class TestRoot(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -632,6 +642,11 @@ class TestRoot(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():

--- a/tests/test_sync_single_child_fk_on_child.py
+++ b/tests/test_sync_single_child_fk_on_child.py
@@ -716,6 +716,11 @@ class TestParentSingleChildFkOnChild(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -1018,6 +1023,11 @@ class TestParentSingleChildFkOnChild(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -1118,6 +1128,11 @@ class TestParentSingleChildFkOnChild(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():

--- a/tests/test_sync_single_child_fk_on_parent.py
+++ b/tests/test_sync_single_child_fk_on_parent.py
@@ -716,6 +716,11 @@ class TestParentSingleChildFkOnParent(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -1009,6 +1014,11 @@ class TestParentSingleChildFkOnParent(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():
@@ -1109,6 +1119,11 @@ class TestParentSingleChildFkOnParent(object):
             sync.logical_slot_changes(txmin=txmin, txmax=txmax)
 
         def poll_redis():
+            payload_tuples = sync.redis.bulk_pop()
+            if payload_tuples:
+                txn_ids, payloads = zip(*payload_tuples)
+                sync.on_publish(payloads, txn_ids)
+
             return []
 
         def poll_db():


### PR DESCRIPTION
Changes the initialization behavior to queue up redis changes from the replication slot data rather than doing an immediate sync on all of that.  This will take advantage of the redis 'sorted set' change to eliminate duplicates.

Additionally, this will keep the replication slot from growing as the system can work on the backlog while data is incoming.