### PR TITLE
SST-719Change pull mechanism to do work in partitions

### DIFF
--- a/pgsync/node.py
+++ b/pgsync/node.py
@@ -167,6 +167,9 @@ class Node(object):
         self.relationship = Relationship(kwargs.get("relationship"))
         self._subquery = None
         self._filters = []
+        self._order_by = None
+        self._limit = None
+        self._offset = None
         self._mapping = {}
 
     def __str__(self):

--- a/pgsync/querybuilder.py
+++ b/pgsync/querybuilder.py
@@ -147,8 +147,15 @@ class QueryBuilder(object):
         if self.from_obj is not None:
             node._subquery = node._subquery.select_from(self.from_obj)
 
+        if node._limit is not None:
+            node._subquery = node._subquery.limit(node._limit)
+        if node._offset is not None:
+            node._subquery = node._subquery.offset(node._offset)
         if node._filters:
             node._subquery = node._subquery.where(sa.and_(*node._filters))
+        if node._order_by is not None:
+            node._subquery = node._subquery.order_by(node._order_by)
+
         node._subquery = node._subquery.alias()
 
     def _children(self, node):

--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -21,7 +21,12 @@ REPLICATION_SLOT_CLEANUP_INTERVAL = env.float(
     "REPLICATION_SLOT_CLEANUP_INTERVAL",
     default=180.0,
 )
-INTERACTIVE_COUNTER = env.bool("INTERACTIVE_COUNTER",default=False)
+# Divids the initial pull(..) query up into X divisions. Helps break
+# up the work to avoid large joins on the server
+INITIAL_PULL_ROWS_PER_SEGMENT = env.int(
+    "INITIAL_PULL_ROWS_PER_SEGMENT", default=100000
+)
+INTERACTIVE_COUNTER = env.bool("INTERACTIVE_COUNTER", default=False)
 
 # Elasticsearch:
 ELASTICSEARCH_SCHEME = env.str("ELASTICSEARCH_SCHEME", default="http")


### PR DESCRIPTION
This makes the initial pull() grab a maximum of INITIAL_PULL_ROWS_PER_SEGMENT rows when syncing the database for the first time.

This is based on the typical limit/offset constructs in the query, using 'order_by' with the primary key for determinism.